### PR TITLE
Max PCOs is now 12 instead of 8, a linked list or vector(reserve?) wo…

### DIFF
--- a/src/common/3gpp_24.008.h
+++ b/src/common/3gpp_24.008.h
@@ -860,7 +860,7 @@ typedef struct protocol_configuration_options_s {
   uint8_t configuration_protocol : 3;
   uint8_t num_protocol_or_container_id;
   // arbitrary value, can be greater than defined (250/3)
-#define PCO_UNSPEC_MAXIMUM_PROTOCOL_ID_OR_CONTAINER_ID 8
+#define PCO_UNSPEC_MAXIMUM_PROTOCOL_ID_OR_CONTAINER_ID 12
   pco_protocol_or_container_id_t
       protocol_or_container_ids[PCO_UNSPEC_MAXIMUM_PROTOCOL_ID_OR_CONTAINER_ID];
 } protocol_configuration_options_t;


### PR DESCRIPTION
Bug root cause is lack of room for PCO elements.