### PR TITLE
URL of required ASN1C Git repository seems to have moved to GitHub

### DIFF
--- a/build/tools/build_helper.asn1c
+++ b/build/tools/build_helper.asn1c
@@ -32,7 +32,7 @@ source $THIS_SCRIPT_PATH/build_helper
 install_asn1c_from_source(){
   if [ $1 -eq 0 ]; then
     OPTION=""
-    read -p "Do you want to install https://gitlab.eurecom.fr/oai/asn1c.git commit f12568d ? <y/N> " prompt
+    read -p "Do you want to install https://github.com/OPENAIRINTERFACE/asn1c commit f12568d ? <y/N> " prompt
   else
     prompt='y'
     OPTION="-y"
@@ -66,7 +66,7 @@ install_asn1c_from_source(){
   then
     $SUDO rm -rf /tmp/asn1c
     mkdir -p /tmp/asn1c
-    GIT_SSL_NO_VERIFY=true git clone https://gitlab.eurecom.fr/oai/asn1c.git /tmp/asn1c
+    GIT_SSL_NO_VERIFY=true git clone https://github.com/OPENAIRINTERFACE/asn1c /tmp/asn1c
     ret=$?;[[ $ret -ne 0 ]] && return $ret
     cd /tmp/asn1c
     git checkout f12568d617dbf48497588f8e227d70388fa217c9


### PR DESCRIPTION
The ASN1C sources repository on Eurecom's server does not seem to exist any more -> MME build fails.

Changed https://gitlab.eurecom.fr/oai/asn1c.git to https://github.com/OPENAIRINTERFACE/asn1c to fix the build issue.
